### PR TITLE
fix: `channel.chat.message` topic version

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -127,7 +127,7 @@ const NotificationHandlers NOTIFICATION_HANDLERS{
         },
     },
     {
-        {"channel.chat.message", "v1"},
+        {"channel.chat.message", "1"},
         [](const auto &metadata, const auto &jv, auto &listener) {
             auto oPayload = parsePayload<
                 eventsub::payload::channel_chat_message::v1::Payload>(jv);


### PR DESCRIPTION
should be `1`, but was `v1`
