### PR TITLE
fix: use header-only boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0087 NEW) # evaluates generator expressions in `install(CODE
 cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_RUNTIME_LIBRARY`
 include(FeatureSummary)
 
-set(TWITCH_EVENTSUB_WS_LIBRARY_TYPE "OBJECT" CACHE STRING "What type of library to build this as (defaults to OBJECT)")
+set(TWITCH_EVENTSUB_WS_LIBRARY_TYPE "STATIC" CACHE STRING "What type of library to build this as (defaults to STATIC)")
 
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0087 NEW) # evaluates generator expressions in `install(CODE
 cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_RUNTIME_LIBRARY`
 include(FeatureSummary)
 
-set(TWITCH_EVENTSUB_WS_LIBRARY_TYPE "STATIC" CACHE STRING "What type of library to build this as (defaults to STATIC)")
+set(TWITCH_EVENTSUB_WS_LIBRARY_TYPE "OBJECT" CACHE STRING "What type of library to build this as (defaults to OBJECT)")
 
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,49 +3,6 @@ from conan.tools.files import copy
 from os import path
 import shutil
 
-BOOST_ALL_OPTIONS = [
-    "atomic",
-    "chrono",
-    "container",
-    "context",
-    "contract",
-    "coroutine",
-    "date_time",
-    "exception",
-    "fiber",
-    "filesystem",
-    "graph",
-    "graph_parallel",
-    "iostreams",
-    "json",
-    "locale",
-    "log",
-    "math",
-    "mpi",
-    "nowide",
-    "program_options",
-    "python",
-    "random",
-    "regex",
-    "serialization",
-    "stacktrace",
-    "system",
-    "test",
-    "thread",
-    "timer",
-    "type_erasure",
-    "url",
-    "wave",
-]
-
-BOOST_ENABLED_OPTIONS = {
-    "container",
-    "json",
-    "system",
-}
-
-BOOST_DISABLED_OPTIONS = [opt for opt in BOOST_ALL_OPTIONS if opt not in BOOST_ENABLED_OPTIONS]
-
 
 class Eventsub(ConanFile):
     name = "Eventsub"
@@ -56,8 +13,8 @@ class Eventsub(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     default_options = {
         "openssl*:shared": True,
+        "boost*:header_only": True,
     }
-    default_options.update({f"boost*:without_{opt}": True for opt in BOOST_DISABLED_OPTIONS})
 
     options = {}
     generators = "CMakeDeps", "CMakeToolchain"
@@ -67,7 +24,6 @@ class Eventsub(ConanFile):
         self.cpp.build.bindirs = ["bin"]
 
     def requirements(self):
-        self.output.warning(BOOST_DISABLED_OPTIONS)
         self.output.warning(self.default_options)
 
     def generate(self):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ set(SOURCE_FILES
 
     chrono.cpp
 
+    json.cpp
+
     payloads/subscription.cpp
     payloads/session-welcome.cpp
 
@@ -36,6 +38,7 @@ target_link_libraries(${PROJECT_NAME}
 
 # See https://github.com/boostorg/beast/issues/2661
 target_compile_definitions(${PROJECT_NAME} PRIVATE BOOST_ASIO_DISABLE_CONCEPTS)
+target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<BOOL:{WIN32}>:BOOST_ALL_NO_LIB>)
 
 # Hack to get the include directories from Python
 get_target_property(_inc_dirs ${PROJECT_NAME} INCLUDE_DIRECTORIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,14 +31,14 @@ target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/.
 
 target_link_libraries(${PROJECT_NAME}
         PUBLIC
-        ${Boost_LIBRARIES}
+        Boost::headers
         OpenSSL::SSL
         OpenSSL::Crypto
         )
 
 # See https://github.com/boostorg/beast/issues/2661
 target_compile_definitions(${PROJECT_NAME} PRIVATE BOOST_ASIO_DISABLE_CONCEPTS)
-target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<BOOL:{WIN32}>:BOOST_ALL_NO_LIB>)
+target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<BOOL:${WIN32}>:BOOST_ALL_NO_LIB>)
 
 # Hack to get the include directories from Python
 get_target_property(_inc_dirs ${PROJECT_NAME} INCLUDE_DIRECTORIES)

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,3 @@
+#ifdef BOOST_ALL_NO_LIB
+#    include <boost/json/src.hpp>
+#endif

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,3 +1,1 @@
-#ifdef BOOST_ALL_NO_LIB
-#    include <boost/json/src.hpp>
-#endif
+#include <boost/json/src.hpp>


### PR DESCRIPTION
We're using header-only boost on Windows, so we need to support that here.

Also, while trying the PR, I couldn't get it to link unless this library is compiled as a static library (which all the other libraries are as well). Note that you can't link an object library to another object library (chatterino-lib for example).